### PR TITLE
Add tab-bar-mode and tab-line-mode config

### DIFF
--- a/chocolate-theme.el
+++ b/chocolate-theme.el
@@ -245,6 +245,14 @@
   (powerline-inactive1 (:background chocolate-syntax-bg-dark :inherit 'mode-line-inactive))
   (powerline-inactive2 (:background chocolate-syntax-bg-dark :inherit 'mode-line-inactive))
   (spaceline-highlight-face (:background chocolate-hue-6 :foreground chocolate-syntax-bg-dark))
+  
+    ;; MODE SUPPORT tab-bar-mode
+  (tab-bar (:foreground chocolate-hue-4 :background chocolate-syntax-bg-dark))
+  (tab-bar-tab (:foreground chocolate-hue-4 :background chocolate-syntax-bg-dark))
+
+  ;; MODE SUPPORT tab-line-mode
+  (tab-line (:foreground chocolate-hue-4 :background chocolate-syntax-bg-dark))
+  (tab-bar-tab-inactive (:foreground chocolate-hue-4 :background chocolate-syntax-bg-dark))
 
   ;; MODE SUPPORT: centaur tabs
   (centaur-tabs-default (:background chocolate-syntax-bg-dark :foreground chocolate-hue-4))


### PR DESCRIPTION
Without these additions the color of the part of the tab-bar without tabs does not get configured, as you can see in the right upper corner of the following screenshot (although the color difference is not very clear here, but the upper right corner is very dark cyan blue). The second following screenshot shows that the color of the tab-bar after the fix of this commit.
![image](https://user-images.githubusercontent.com/18429791/97000482-14b93a00-1537-11eb-8014-09aba5fb82b5.png)

![image](https://user-images.githubusercontent.com/18429791/97000441-0539f100-1537-11eb-8196-52848e42cc68.png)
