### PR TITLE
improve readability for selectrum

### DIFF
--- a/chocolate-theme.el
+++ b/chocolate-theme.el
@@ -184,6 +184,9 @@
   (ivy-current-match (:weight 'bold :background chocolate-mono-3))
   (ivy-cursor (:foreground chocolate-hue-2 :background chocolate-syntax-bg-dark))
 
+  ;; MODE SUPPORT: selectrum
+  (selectrum-current-candidate (:background chocolate-syntax-light))
+
   ;; MODE support: js2
   (js2-function-param (:foreground chocolate-hue-1))
   (js2-external-variable (:weight 'bold :foreground chocolate-hue-7))


### PR DESCRIPTION
Readability for selected candidate can be poor because of bright background; this changes the background so the text is more easily readable.

current:
<img width="650" alt="x1" src="https://user-images.githubusercontent.com/43703153/105528877-724b5700-5cdd-11eb-87d7-41eb38ab6b2c.png">

<img width="650" alt="x2" src="https://user-images.githubusercontent.com/43703153/105528888-76777480-5cdd-11eb-948e-332df71d5944.png">

